### PR TITLE
Arreglo para el calculo correcto de la Silueta

### DIFF
--- a/app/src/main/java/com/example/fran/imachineappv2/MainActivityModel.java
+++ b/app/src/main/java/com/example/fran/imachineappv2/MainActivityModel.java
@@ -543,6 +543,8 @@ public class MainActivityModel implements MainActivityMvpModel {
 
         affinityMatrix = MCLDenseEJML.averageMatrices(matList);
 
+        DMatrixRMaj affinityMatrix2 = affinityMatrix.copy();
+
         // Now run MCL clustering over A with the given parameters
         MCLDenseEJML mcl = new MCLDenseEJML(maxIt, expPow, infPow, epsConvergence, threshPrune);
         clusterMatrix = mcl.run(affinityMatrix);
@@ -563,12 +565,12 @@ public class MainActivityModel implements MainActivityMvpModel {
             }
         }
 
-        MCLDenseEJML.postCluster(vClusters, affinityMatrix);
+        MCLDenseEJML.postCluster(vClusters, affinityMatrix2);
 
         // if (mainActivityPresenter != null)
         //    mainActivityPresenter.clustersReady();
 
-        return affinityMatrix;
+        return affinityMatrix2;
     }
 
     @SuppressLint("DefaultLocale")


### PR DESCRIPTION
Se detectó un issue a la hora de calcular la medida de la Silueta. El problema estaba en que no se retornaba la matriz de afinidad correcta, sino que se retornaba una similar a clusterMatrix (ya me había topado con este problema en una vieja ocasión, un gran dolor de cabeza hasta detectarlo jaja), debido al proceso MCLDenseEJML.run(affinityMatrix).

Se hace una copia de la affinityMatrix (affinityMatrix2), y se utiliza tanto para el método MCLDenseEJML.postCluster(vClusters, affinityMatrix2) como en el retorno de la función.

Ahora la medida de la Silueta es calculada de manera correcta.